### PR TITLE
Fixes an elided lifetime causing a warning with newer compiler versions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -552,7 +552,7 @@ pub struct PasswordParams<'a> {
 /// parse_challenges("UnsupportedSchemeA, Basic realm=\"foo\", error error").unwrap_err();
 /// ```
 #[inline]
-pub fn parse_challenges(input: &str) -> Result<Vec<ChallengeRef>, parser::Error> {
+pub fn parse_challenges(input: &str) -> Result<Vec<ChallengeRef<'_>>, parser::Error<'_>> {
     parser::ChallengeParser::new(input).collect()
 }
 


### PR DESCRIPTION
Super minor change, fixes a warning with latest compiler versions:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/lib.rs:555:32
    |
555 | pub fn parse_challenges(input: &str) -> Result<Vec<ChallengeRef>, parser::Error> {
    |                                ^^^^                ------------   ------------- the same lifetime is hidden here
    |                                |                   |
    |                                |                   the same lifetime is hidden here
    |                                the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
555 | pub fn parse_challenges(input: &str) -> Result<Vec<ChallengeRef<'_>>, parser::Error<'_>> {
    |                                                                ++++                ++++
```